### PR TITLE
Allow installing phpstan 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require": {
         "php": "^8.0",
         "php-di/php-di": "^7.0",
-        "phpstan/phpstan": "^1.10"
+        "phpstan/phpstan": "^1.10|^2.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Fixes #1 

Allows using this extension in combination with PHPStan 2.0